### PR TITLE
getting rid of freq sweeps in each note

### DIFF
--- a/final-project/js/main_helpers.js
+++ b/final-project/js/main_helpers.js
@@ -83,7 +83,7 @@ let reset_synth = () => {
         synth = null
     }
     
-    synth = new Tone.MembraneSynth().toMaster()
+    synth = new Tone.Synth().toMaster()
 }
 
 


### PR DESCRIPTION
glad to see you fixed the initial ghost note.
Regarding the frequency sweeps that is due to the type of synth you're [using](https://tonejs.github.io/docs/13.8.25/MembraneSynth.html).
Should you use another Synth like this one, it will work just fine.

OCH