### PR TITLE
Add option for Dvorak and Colemak keymaps

### DIFF
--- a/week5-synthesize/js/synth.js
+++ b/week5-synthesize/js/synth.js
@@ -1,10 +1,23 @@
 let harmonics = [...Array(16).keys()].map(k => k + 1)   // https://stackoverflow.com/questions/3895478/
 
-const keymap = {
+const qwertyKeymap = {
     'a': 220,       's': 246.94,    'd': 277.18,
     'f': 293.66,    'j': 329.63,    'k': 369.99,
     'l': 415.30,    ';': 440
 }
+
+const colemakKeymap = {
+    'a': 220,       'r': 246.94,    's': 277.18,
+    't': 293.66,    'n': 329.63,    'e': 369.99,
+    'i': 415.30,    'o': 440
+}
+
+const dvorakKeymap = {
+    'a': 220,       'o': 246.94,    'e': 277.18,
+    'u': 293.66,    'h': 329.63,    't': 369.99,
+    'n': 415.30,    's': 440
+}
+
 
 const context = new AudioContext()
 
@@ -93,11 +106,24 @@ getKeyPressed = (event) => {
 getFrequency = (event) => {
     const key = getKeyPressed(event).replace(':', ';')
     const octiveMultiplier = event.shiftKey ? 2 : 1
+    const keymap = getKeymap()
 
     if (key in keymap)
         return keymap[key] * octiveMultiplier
     else if (key === ' ')
         return note.frequency * Math.pow(2, 1 / 12) // adjust the old note slightly
+}
+
+getKeymap = () => {
+    const keymap = document.getElementById("keymap").value
+    switch (keymap) {
+        case "colemak":
+            return colemakKeymap
+        case "dvorak":
+            return dvorakKeymap
+        default:
+            return qwertyKeymap 
+    }
 }
 
 document.onkeydown = (event) => {

--- a/week5-synthesize/synth.md
+++ b/week5-synthesize/synth.md
@@ -11,10 +11,10 @@ permalink: /synth
 
 &nbsp;
 
-### Type with the home row (asdfjkl;)
+### Type with the home row (e.g. asdfjkl; for Qwerty)
 
 <div style="display: flex">
-    <div style="width: 30%; height: 400px">
+    <div style="width: 30%; height: 500px">
         <br><br>
         <label for="harmonicsSlider">Number of Overtones</label><br>
         <input type="range" min="1" max="16" value="16" step="1" id="harmonicsSlider"><br><br>
@@ -23,7 +23,13 @@ permalink: /synth
         <label for="vibratoDepthSlider">Vibrato Depth</label><br>
         <input type="range" min="0.01" max="30" value="15" step="0.01" id="vibratoDepthSlider"><br><br>
         <label for="vibratoDelaySlider">Vibrato Onset Delay</label><br>
-        <input type="range" min="0.01" max="3" value="2" step="0.01" id="vibratoDelaySlider">
+        <input type="range" min="0.01" max="3" value="2" step="0.01" id="vibratoDelaySlider"><br><br>
+        <label>Keyboard Layout</label><br>
+        <select name="keymap" id="keymap">
+          <option value="qwerty" selected="selected">Qwerty</option>
+          <option value="colemak">Colemak</option>
+          <option value="dvorak">Dvorak</option>
+        </select>
     </div>
     <div id="harmonicsPlot" style="flex-grow: 1"></div>
 </div>


### PR DESCRIPTION
<img width="750" alt="image" src="https://github.com/user-attachments/assets/66b8a326-abcc-4823-886d-714b72b82e5a">
Because not everyone uses the Qwerty keyboard layout, this PR introduces additional keymap options to allow for ergonomic music creation.